### PR TITLE
Fix // ModeNaming

### DIFF
--- a/ApplianceResponse.js
+++ b/ApplianceResponse.js
@@ -97,7 +97,7 @@ class ApplianceResponse {
     }
 
     get dryClean() {
-        // This needs a better name, dunno what it actually means
+        // This actually means 13°C(55°F)~35°C(95°F) according to my manual. Also dehumidifying.
         return (this.data[0x09] & 0x04) > 0;
     }
 


### PR DESCRIPTION
The modes are always described in the devices manuals. So they probably differ from device to device. 
I guess there is nothing wrong with keeping the names as they are now since they are more or less just placeholders for the devices real modes.

Correct me if I am wrong.