### PR TITLE
A missing comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to the platforms array in your config.json:
 	    "interval": 1,
 	    "devices": [
 	    	{
-	    		"deviceId": "DEVICE_ID"
+	    		"deviceId": "DEVICE_ID",
 	    		"supportedSwingMode": "Vertical",
 				"temperatureSteps": 1
 	    	}


### PR DESCRIPTION
A missing comma at the end of the line of device id.